### PR TITLE
Add 3rd party license to nuget package

### DIFF
--- a/src/AWS.DistributedCacheProvider/AWS.DistributedCacheProvider.csproj
+++ b/src/AWS.DistributedCacheProvider/AWS.DistributedCacheProvider.csproj
@@ -28,6 +28,7 @@
 		<None Include="..\..\LICENSE" Pack="true" PackagePath="" />
 		<None Include="..\..\NOTICE" Pack="true" PackagePath="" />
 		<None Include="..\..\icon.png" Pack="true" PackagePath="" />
+		<None Include="..\..\THIRD-PARTY-LICENSES.txt" Pack="true" PackagePath="" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6185
*Description of changes:*
The 3rd party license file should be included in the nupkg file when packaging the library for release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
