### PR TITLE
ci: add STS dependency to integ test project

### DIFF
--- a/test/AWS.DistributedCacheProviderIntegrationTests/AWS.DistributedCacheProviderIntegrationTests.csproj
+++ b/test/AWS.DistributedCacheProviderIntegrationTests/AWS.DistributedCacheProviderIntegrationTests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.11" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.22" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
*Description of changes:*
Release pipeline failing on integ test stage due to missing STS dependency. 
This change adds the dependency to the integ test project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
