### PR TITLE
fix: Rework DynamoDBDistributedCache initialization to initialize ILoggerFactory correctly

### DIFF
--- a/src/AWS.DistributedCacheProvider/DynamoDBDistributedCache.cs
+++ b/src/AWS.DistributedCacheProvider/DynamoDBDistributedCache.cs
@@ -10,6 +10,7 @@ using Amazon.Runtime;
 using System.Reflection;
 using System.Text;
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Options;
 
 namespace AWS.DistributedCacheProvider
 {
@@ -43,14 +44,14 @@ namespace AWS.DistributedCacheProvider
         /// <param name="client">DynamoDB Client</param>
         /// <param name="creator">Creator class that is responsible for creating or validating the DynamoDB Table</param>
         /// <param name="options">Configurable options for the cache</param>
-        /// <exception cref="ArgumentNullException"></exception>
-        public DynamoDBDistributedCache(IAmazonDynamoDB client, IDynamoDBTableCreator creator, DynamoDBDistributedCacheOptions options, ILoggerFactory? loggerFactory = null)
+        /// <exception cref="ArgumentNullException">Thrown when one of the required parameters is null</exception>
+        public DynamoDBDistributedCache(IAmazonDynamoDB client, IDynamoDBTableCreator creator, IOptions<DynamoDBDistributedCacheOptions> options, ILoggerFactory? loggerFactory = null)
         {
             if (client == null)
             {
                 throw new ArgumentNullException(nameof(client));
             }
-            if (options == null)
+            if (options == null || options.Value == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
@@ -58,7 +59,7 @@ namespace AWS.DistributedCacheProvider
             {
                 throw new ArgumentNullException(nameof(creator));
             }
-            if(options.TableName == null)
+            if(options.Value.TableName == null)
             {
                 throw new ArgumentException("TableName must be specified in the DynamoDBDistributedCacheOptions parameter");
             }
@@ -72,14 +73,14 @@ namespace AWS.DistributedCacheProvider
             }
             _ddbClient = client;
             _dynamodbTableCreator = creator;
-            _consistentReads = options.UseConsistentReads;
-            _tableName = options.TableName!;
-            _createTableifNotExists = options.CreateTableIfNotExists;            
-            _partitionKeyPrefix = options.PartitionKeyPrefix;
+            _consistentReads = options.Value.UseConsistentReads;
+            _tableName = options.Value.TableName;
+            _createTableifNotExists = options.Value.CreateTableIfNotExists;
+            _partitionKeyPrefix = options.Value.PartitionKeyPrefix;
 
             // Use ! because there is a delay to _partitionKey and _ttlDateAttributeName being initialized during StartupAsync
-            _partitionKey = options.PartitionKeyName!;
-            _ttlDateAttributeName = options.TTLAttributeName!;
+            _partitionKey = options.Value.PartitionKeyName!;
+            _ttlDateAttributeName = options.Value.TTLAttributeName!;
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Internal testing discovered that even when an application was configured with a `Trace` or `Debug` logging level, we were only seeing messages from `DynamoDBTableCreator` but not `DynamoDBDistributedCache`

**Before:** `AddAWSDynamoDBDistributedCache` was calling the `DynamoDBDistributedCache` constructor explicitly with three arguments that it resolved from `IServiceProvider.GetRequiredService`, but it was never setting the `ILoggerFactory` so a `NullLogger` was always being used.

**After**: Now `AddAWSDynamoDBDistributedCache`  adds our known required services and then ultimately calls `services.AddSingleton<IDistributedCache, DynamoDBDistributedCache>();` so that the DI framework is ultimately invoking the constructor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
