### PR TITLE
chore: Add security focused test cases

### DIFF
--- a/test/AWS.DistributedCacheProviderIntegrationTests/DynamoDBDistributedCacheTableTests.cs
+++ b/test/AWS.DistributedCacheProviderIntegrationTests/DynamoDBDistributedCacheTableTests.cs
@@ -38,6 +38,12 @@ namespace AWS.DistributedCacheProviderIntegrationTests
                 //resolving the table should pass.
                 //Key cannot be empty, otherwise the client will throw an exception
                 cache.Get("randomCacheKey");
+
+                var table = (await client.DescribeTableAsync(tableName)).Table;
+
+                // Null value indicates that data in the table is encrypted at rest via an AWS owned KMS key.
+                // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html
+                Assert.Null(table.SSEDescription);
             }
             finally
             {


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7001

*Description of changes:*
* Update integration test to assert on the encryption setting after creating a DDB table.
* Add unit test to check that expired keys return null even if they still exist in the DDB table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
