### PR TITLE
chore: add PackageReadmeFile attribute to show README file in NuGet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.2 (2023-07-28)
+- Add PackageReadmeFile attribute to show README file in NuGet
+
 ## 0.9.1 (2023-07-28)
 - Added the repository README file to the NuGet package
 

--- a/src/AWS.DistributedCacheProvider/AWS.DistributedCacheProvider.csproj
+++ b/src/AWS.DistributedCacheProvider/AWS.DistributedCacheProvider.csproj
@@ -5,7 +5,7 @@
 		<RootNamespace>AWS.DistributedCacheProvider</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>0.9.1</Version>
+		<Version>0.9.2</Version>
 		<PackageId>AWS.AspNetCore.DistributedCacheProvider</PackageId>
 		<Title>AWS Provider for ASP.NET Core's IDistributedCache</Title>
 		<Description>The AWS Distributed Cache provider provides an IDistributedCache implementation backed by DynamoDB.</Description>
@@ -19,6 +19,8 @@
 
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
+
+    <PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7069

*Description of changes:*
- Add PackageReadmeFile attribute to show README file in NuGet

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
