### PR TITLE
chore: Add GitHub workflows for stale issue/discussions and closed issue message.

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -1,0 +1,17 @@
+name: Closed Issue Message
+on:
+    issues:
+       types: [closed]
+jobs:
+    auto_comment:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: aws-actions/closed-issue-message@v1
+          with:
+            # These inputs are both required
+            repo-token: "${{ secrets.GITHUB_TOKEN }}"
+            message: |
+                     ### ⚠️COMMENT VISIBILITY WARNING⚠️ 
+                     Comments on closed issues are hard for our team to see. 
+                     If you need more assistance, please either tag a team member or open a new issue that references this one. 
+                     If you wish to keep having a conversation with other community members under this issue feel free to do so.

--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -1,0 +1,18 @@
+name: HandleStaleDiscussions
+on:
+  schedule:
+    - cron: '0 */4 * * *'
+  discussion_comment:
+    types: [created]
+
+jobs:
+  handle-stale-discussions:
+    name: Handle stale discussions
+    runs-on: ubuntu-latest
+    permissions:
+      discussions: write
+    steps:
+      - name: Stale discussions action
+        uses: aws-github-ops/handle-stale-discussions@v1
+        env:
+          GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,46 @@
+name: "Close stale issues"
+
+# Controls when the action will run.
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v6
+      with:
+        # Setting messages to an empty string will cause the automation to skip
+        # that category
+        ancient-issue-message: We have noticed this issue has not received attention in 1 year. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
+        stale-issue-message: This issue has not received a response in 5 days. If you want to keep this issue open, please just leave a comment below and auto-close will be canceled.
+
+        # These labels are required
+        stale-issue-label: closing-soon
+        exempt-issue-labels: no-autoclose
+        stale-pr-label: no-pr-activity
+        exempt-pr-labels: awaiting-approval
+        response-requested-label: response-requested
+
+        # Don't set closed-for-staleness label to skip closing very old issues
+        # regardless of label
+        closed-for-staleness-label: closed-for-staleness
+
+        # Issue timing
+        days-before-stale: 5
+        days-before-close: 2
+        days-before-ancient: 36500
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 10
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        #loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        #dry-run: true
+  


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Added GitHub workflows for stale issue/discussions and closed issue message. These were somehow missing from this repository.

___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
