### PR TITLE
chore: add workflow to check if change file is included in a PR

### DIFF
--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -1,0 +1,30 @@
+name: Change File Included in PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  check-files-in-directory:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}
+    name: Change File Included in PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v3
+
+      - name: Get List of Changed Files
+        id: changed-files
+        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf #v45
+
+      - name: Check for Change File(s) in .autover/changes/
+        run: |
+          DIRECTORY=".autover/changes/"
+          if echo "${{ steps.changed-files.outputs.all_changed_files }}" | grep -q "$DIRECTORY"; then
+            echo "✅ One or more change files in '$DIRECTORY' are included in this PR."
+          else
+            echo "❌ No change files in '$DIRECTORY' are included in this PR."
+            echo "Refer to the 'Adding a change file to your contribution branch' section of https://github.com/awslabs/aws-dotnet-distributed-cache-provider/blob/main/CONTRIBUTING.md"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,49 @@ To send us a pull request, please:
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
+## Adding a `change file` to your contribution branch
+
+Each contribution branch should include a `change file` that contains a changelog message for each project that has been updated, as well as the type of increment to perform for those changes when versioning the project.
+
+A `change file` looks like the following example:
+```json
+{
+  "Projects": [
+    {
+      "Name": "AWS.AspNetCore.DistributedCacheProvider",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed an issue causing a failure somewhere"
+      ]
+    }
+  ]
+}
+```
+The `change file` lists all the modified projects, the changelog message for each project as well as the increment type. 
+
+These files are located in the repo at .autover/changes/
+
+You can use the `AutoVer` tool to create the change file. You can install it using the following command:
+```
+dotnet tool install -g AutoVer
+```
+
+You can create the `change file` using the following command:
+```
+autover change --project-name "AWS.AspNetCore.DistributedCacheProvider" -m "Fixed an issue causing a failure somewhere
+```
+Note: Make sure to run the command from the root of the repository.
+
+You can update the command to specify which project you are updating.
+The available projects are:
+* AWS.AspNetCore.DistributedCacheProvider
+
+The possible increment types are:
+* Patch
+* Minor
+* Major
+
+Note: You do not need to create a new `change file` for every changelog message or project within your branch. You can create one `change file` that contains all the modified projects and the changelog messages.
 
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.


### PR DESCRIPTION
*Description of changes:*
The PR updates the CONTRIBUTION.md file and adds a new Workflow that checks if a PR contains a `change` file. If a change file is not required, PRs should add the label `Release Not Needed`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
