### PR TITLE
chore: switch v4sdk branch references to main/dev

### DIFF
--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - v4sdk-release # Change to `main` when V4 is GA
-      - v4sdk-development # Change to `dev` when V4 is GA
+      - main
+      - dev
       - 'feature/**'
 
 permissions:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,8 +1,8 @@
 # This GitHub Workflow will create a new release branch that contains the updated C# project versions and changelog.
-# The workflow will also create a PR that targets `v4sdk-development` from the release branch.
+# The workflow will also create a PR that targets `dev` from the release branch.
 name: Create Release PR
 
-# This workflow is manually triggered when in preparation for a release. The workflow should be dispatched from the `v4sdk-development` branch.
+# This workflow is manually triggered when in preparation for a release. The workflow should be dispatched from the `dev` branch.
 on:
   workflow_dispatch:
     inputs:
@@ -96,6 +96,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
         run: |
-          pr_url="$(gh pr create --title "${{ steps.read-release-name.outputs.VERSION }}" --body "${{ steps.read-changelog.outputs.CHANGELOG }}" --base v4sdk-development --head ${{ steps.create-release-branch.outputs.BRANCH }})"
+          pr_url="$(gh pr create --title "${{ steps.read-release-name.outputs.VERSION }}" --body "${{ steps.read-changelog.outputs.CHANGELOG }}" --base dev --head ${{ steps.create-release-branch.outputs.BRANCH }})"
           gh label create "Release PR" --description "A Release PR that includes versioning and changelog changes" -c "#FF0000" -f
           gh pr edit $pr_url --add-label "Release PR"

--- a/.github/workflows/sync-main-dev.yml
+++ b/.github/workflows/sync-main-dev.yml
@@ -2,7 +2,7 @@
 # This GitHub Workflow is designed to run automatically after the Release PR, which was created by the `Create Release PR` workflow, is closed.
 # This workflow has 2 jobs. One will run if the `Release PR` is successfully merged, indicating that a release should go out.
 # The other will run if the `Release PR` was closed and a release is not intended to go out.
-name: Sync 'v4sdk-development' and 'v4sdk-release'
+name: Sync 'dev' and 'main'
 
 # The workflow will automatically be triggered when any PR is closed.
 on:
@@ -14,15 +14,15 @@ permissions:
   id-token: write
 
 jobs:
-  # This job will check if the PR was successfully merged, it's source branch is `releases/next-release` and target branch is `v4sdk-development`. 
+  # This job will check if the PR was successfully merged, it's source branch is `releases/next-release` and target branch is `dev`. 
   # This indicates that the merged PR was the `Release PR`. 
-  # This job will synchronize `v4sdk-development` and `v4sdk-release`, create a GitHub Release and delete the `releases/next-release` branch.
+  # This job will synchronize `dev` and `main`, create a GitHub Release and delete the `releases/next-release` branch.
   sync-dev-and-main:
-    name: Sync v4sdk-development and v4sdk-release
+    name: Sync dev and main
     if: |
       github.event.pull_request.merged == true &&
       github.event.pull_request.head.ref == 'releases/next-release' &&
-      github.event.pull_request.base.ref == 'v4sdk-development'
+      github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
     steps:
       # Assume an AWS Role that provides access to the Access Token
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
-          ref: v4sdk-development
+          ref: dev
           fetch-depth: 0
           token: ${{ env.AWS_SECRET_TOKEN }}
       # Install .NET8 which is needed for AutoVer
@@ -76,13 +76,13 @@ jobs:
         run: |
           changelog=$(autover changelog --output-to-console)
           echo "CHANGELOG<<EOF"$'\n'"$changelog"$'\n'EOF >> "$GITHUB_OUTPUT"
-      # Merge v4sdk-development into v4sdk-release in order to synchronize the 2 branches
-      - name: Merge v4sdk-development to v4sdk-release
+      # Merge dev into main in order to synchronize the 2 branches
+      - name: Merge dev to main
         run: |
           git fetch origin
-          git checkout v4sdk-release
-          git merge v4sdk-development
-          git push origin v4sdk-release
+          git checkout main
+          git merge dev
+          git push origin main
       # Create the GitHub Release
       - name: Create GitHub Release
         env:
@@ -94,7 +94,7 @@ jobs:
         run: |
           git fetch origin
           git push origin --delete releases/next-release
-  # This job will check if the PR was closed, it's source branch is `releases/next-release` and target branch is `v4sdk-development`. 
+  # This job will check if the PR was closed, it's source branch is `releases/next-release` and target branch is `dev`. 
   # This indicates that the closed PR was the `Release PR`.
   # This job will delete the tag created by AutoVer and the release branch.
   clean-up-closed-release:
@@ -102,7 +102,7 @@ jobs:
     if: |
       github.event.pull_request.merged == false &&
       github.event.pull_request.head.ref == 'releases/next-release' &&
-      github.event.pull_request.base.ref == 'v4sdk-development'
+      github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
     steps:
       # Checkout a full clone of the repo


### PR DESCRIPTION
*Description of changes:*
Switch all v4sdk-release/v4sdk-development branch references to main/dev

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
